### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pycocotools
 scikit-image
 imageio
 pandas
+imgaug==0.4.0


### PR DESCRIPTION
eval.py requires the latest version of imgaug, which is 0.4.0. Without it, you get this error message:
ImportError: cannot import name 'SegmentationMapsOnImage' from 'imgaug.augmentables.segmaps' (/usr/local/lib/python3.7/dist-packages/imgaug/augmentables/segmaps.py)